### PR TITLE
OTMZ-1168 | Edit to use match when searching job code

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -118,7 +118,7 @@ class SearchService {
                 match_phrase_prefix: { name: string },
             },
             {
-                match_phrase_prefix: { "code.text": string },
+                match: { "code.text": string },
             },
             {
                 nested: {

--- a/src/service.ts
+++ b/src/service.ts
@@ -195,7 +195,7 @@ export class SearchService<D extends Document> implements Provider<D> {
         match_phrase_prefix: { name: string },
       },
       {
-        match_phrase_prefix: { "code.text": string },
+        match: { "code.text": string },
       },
       {
         nested: {


### PR DESCRIPTION
Task https://gupy-io.atlassian.net/browse/OTMZ-1168

Descrição:
Atualmente estamos realizando a busca no código da vaga utilizando match_phrase_prefix e isso acabou gerando para um cliente o mesmo problema que tivemos para a via varejo, com o código de posição.
A sugestão é fazer a alteração de match_phrase_prefix para match, como foi feito para o código de posição, até que façamos uma solução definitiva para ambos os campos.