### PR TITLE
[TRIA-872] Remove unecessary error log from bulk

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -58,8 +58,6 @@ class SearchService {
                 .filter((item) => !!this.getAction(item).error)
                 // eslint-disable-next-line
                 .map((item) => this.getAction(item).error);
-            // This logger is temporary and will be removed soon
-            this.logger.error("Error on bulk request (complete log)", response.body);
             throw new BulkError("Error on bulk request", errors);
         }
     }

--- a/src/service.ts
+++ b/src/service.ts
@@ -131,8 +131,6 @@ export class SearchService<D extends Document> implements Provider<D> {
         .filter((item: any) => !!this.getAction(item).error)
         // eslint-disable-next-line
         .map((item: any) => this.getAction(item).error);
-      // This logger is temporary and will be removed soon
-      this.logger.error("Error on bulk request (complete log)", response.body);
       throw new BulkError("Error on bulk request", errors);
     }
   }


### PR DESCRIPTION
Problem:
- This log was created to analyze an error, but it should have been removed Immediately after fix.
- Now Sentry is accumulating this log and exceeding the quota.

Fix:
- Just remove the complete log.