### PR TITLE
Reduce document loss on migrateLockdown

### DIFF
--- a/lib/migration/index.js
+++ b/lib/migration/index.js
@@ -46,6 +46,7 @@ class IndexManager {
         await this.swap(this.esConfig.index, stageIndex);
         await this.deleteIndex();
         await this.createIndex();
+        await this.refreshIndex(stageIndex);
         await this.duplicate(stageIndex, this.esConfig.index);
         await this.swap(stageIndex, this.esConfig.index);
         await this.deleteIndex(stageIndex);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchops",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Base operation files for search service",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/migration/index.ts
+++ b/src/migration/index.ts
@@ -68,6 +68,7 @@ export class IndexManager {
     await this.swap(this.esConfig.index, stageIndex);
     await this.deleteIndex();
     await this.createIndex();
+    await this.refreshIndex(stageIndex);
     await this.duplicate(stageIndex, this.esConfig.index);
     await this.swap(stageIndex, this.esConfig.index);
     await this.deleteIndex(stageIndex);

--- a/test/build/package.json
+++ b/test/build/package.json
@@ -5,7 +5,7 @@
     "build": "rm -rf ../../node_modules && tsc --noEmit"
   },
   "dependencies": {
-    "searchops": "file:../../searchops-0.0.9.tgz"
+    "searchops": "file:../../searchops-0.0.10.tgz"
   },
   "devDependencies": {
     "@types/node": "^14.11.2",


### PR DESCRIPTION
Usando o método `IndexManager#migrateLockdown` pra atualizar um mapping incompatível eu percebi que o novo índice sempre ficava vazio (rodando localmente), e acompanhando as operações vi que a primeira cópia (índice original -> tmp) funcionava corretamente, mas a segunda cópia (índice tmp -> novo) não copiava nenhum documento.

Imaginei que poderia ser um problema de concorrência entre as operações da lib e o estado interno do cluster e adicionei um _refresh_ antes da seguda cópia pra forçar a lib esperar o cluster processar os novos documentos, e funcionou :tada: 